### PR TITLE
Revert "Leave the channels opened for a bit more time to make sure the state change gets"

### DIFF
--- a/ofonocallchannel.cpp
+++ b/ofonocallchannel.cpp
@@ -341,10 +341,9 @@ void oFonoCallChannel::onOfonoCallStateChanged(const QString &state)
         }
         mCallChannel->setCallState(Tp::CallStateEnded, 0, reason, stateDetails);
         // just in case, leave the channel opened for one more second before unregistering from bus
-        QTimer::singleShot(1000, [=]() {
-            Q_EMIT closed();
-            mBaseChannel->close();
-        });
+        QThread::msleep(1000);
+        Q_EMIT closed();
+        mBaseChannel->close();
     } else if (state == "active") {
         qDebug() << "active";
         mHoldIface->setHoldState(Tp::LocalHoldStateUnheld, Tp::LocalHoldStateReasonNone);

--- a/ofonoconferencecallchannel.cpp
+++ b/ofonoconferencecallchannel.cpp
@@ -120,9 +120,8 @@ void oFonoConferenceCallChannel::onChannelSplitted(const QDBusObjectPath &path)
 
         mCallChannel->setCallState(Tp::CallStateEnded, 0, reason, stateDetails);
         // just in case, delay the channel closing by 1 second
-        QTimer::singleShot(1000, [=]() {
-            mBaseChannel->close();
-        });
+        QThread::msleep(1000);
+        mBaseChannel->close();
     }
 }
 


### PR DESCRIPTION
It says this got added because "Leave the channels opened for a bit more time to make sure the state change gets fired and delivered correctly", but it makes telepathy segfault so it makes matter lots worse!

This fixes https://github.com/ubports/telepathy-ofono/issues/1 and  https://github.com/ubports/ubuntu-touch/issues/860

This reverts commit 301303f683c4311d41caa553fcf9d6dc2f144ec5.