### PR TITLE
Fix MMS group creation and maintenance

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -790,8 +790,8 @@ Tp::BaseChannelPtr oFonoConnection::createTextChannel(const QVariantMap &request
         }
         // we got the groupId, now lookup the members and subject in the cache
         MMSGroup group = MMSGroupCache::existingGroup(targetId);
-        if (group.groupId.isEmpty() && !initialInviteeIDs.isEmpty()) {
-            // save new group if we have initial invitee ids and no group is found in cache
+        if (group.groupId.isEmpty() && (!initialInviteeIDs.isEmpty() || !phoneNumbers.isEmpty())) {
+            // save new group if we have initial invitees but no group was found in cache
             group.groupId = targetId;
             group.members = phoneNumbers;
             MMSGroupCache::saveGroup(group);


### PR DESCRIPTION
Currently it is possible to send and receive 1-on-1 MMS (mostly), but groups only work if the Ubuntu Touch user creates them. This work will explore what it takes to get MMS group support working correctly.

Currently I've found that:

* Getting a group created was the easy part
* There might be a race condition in delivering the MMS message to the new group. With these changes, groups are created but without the first message.
* Deleting a group in the messaging app does not completely delete it. The group will not display in the app after the deletion, even if new messages are sent.