### PR TITLE
add a check for sent date not properly set

### DIFF
--- a/ofonotextchannel.cpp
+++ b/ofonotextchannel.cpp
@@ -522,8 +522,9 @@ void oFonoTextChannel::mmsReceived(const QString &id, uint handle, const QVarian
 QDateTime oFonoTextChannel::getSentDate(const QString &sentTime){
     QDateTime dt = QDateTime::fromString(sentTime, Qt::ISODate);
     QDateTime currentDate  = QDateTime::currentDateTimeUtc();
-    //some text message may not have the Sentime set, use the received one in that case
-    if (!dt.isValid() || dt > currentDate){
+    // some text message may not have the Sentime set or having a 0 unix timestamp, use the received one in that case
+    // assuming that a sentdate less than four months ago is not a valid date
+    if (!dt.isValid() || dt > currentDate || dt < currentDate.addDays(-120)){
         dt = currentDate;
     }
 


### PR DESCRIPTION
Volla-phone users report an invalid sms sent date in notification (Thu, 1. Jan 1:00 am)
see:
https://forums.ubports.com/topic/5056/vollaphone-notifications-wrong-date-time-for-new-sms/11

The idea is to check if sent time is not too far from the received one.

