### PR TITLE
ussdiface: fix the incorrect use of indexOfMethod()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,65 +1,7 @@
-pipeline {
-  agent any
-  stages {
-    stage('Build source') {
-      steps {
-        sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-    stage('Build binary - armhf') {
-      steps {
-        parallel(
-          "Build binary - armhf": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="armhf"
-build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
+@Library('ubports-build-tools') _
 
+buildAndProvideDebianPackage()
 
-          },
-          "Build binary - arm64": {
-            node(label: 'arm64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="arm64"
-    build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          },
-          "Build binary - amd64": {
-            node(label: 'amd64') {
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-              unstash 'source'
-              sh '''export architecture="amd64"
-    build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
-              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-            }
-          }
-        )
-      }
-    }
-    stage('Results') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        unstash 'build-armhf'
-        unstash 'build-arm64'
-        unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
-        sh '''/usr/bin/build-repo.sh'''
-      }
-    }
-    stage('Cleanup') {
-      steps {
-        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-      }
-    }
-  }
-}
+// Or if the package consists entirely of arch-independent packages:
+// (optiional optimization, will confuse BlueOcean's live view at build stage)
+// buildAndProvideDebianPackage(/* isArchIndependent */ true)

--- a/ussdiface.cpp
+++ b/ussdiface.cpp
@@ -256,7 +256,7 @@ ConnectionInterfaceUSSDAdaptor::~ConnectionInterfaceUSSDAdaptor()
 
 void ConnectionInterfaceUSSDAdaptor::Initiate(const QString &command, const QDBusMessage& dbusMessage)
 {
-    if (adaptee()->metaObject()->indexOfMethod("initiate(const QString &,ConnectionInterfaceUSSDAdaptor::InitiateContextPtr)") == -1) {
+    if (adaptee()->metaObject()->indexOfMethod("initiate(QString,ConnectionInterfaceUSSDAdaptor::InitiateContextPtr)") == -1) {
         dbusConnection().send(dbusMessage.createErrorReply(TP_QT_ERROR_NOT_IMPLEMENTED, QLatin1String("Not implemented")));
         return;
     }


### PR DESCRIPTION
The argument of indexOfMethod() is supposed to be normallized [1]. The
"const &" shouldn't be around the QString type. Having one make Qt fails
to find the method, always triggering the error code.

It has always been incorrect, but it doesn't cause a problem because the
error handling was incorrect. Commit fc1e09e187a1 ("fix error handling
logic") fixes it, thus exposing this problem.

Fixes https://github.com/HelloVolla/ubuntu-touch-beta-tests/issues/38
Fixes https://github.com/ubports/ubuntu-touch/issues/1592
Should also fixes the problem on PinePhone as it uses the same code, but
I can't find the filed issue.

[1] https://doc.qt.io/qt-5/qmetaobject.html#indexOfMethod