### PR TITLE
Failed MMS redownload

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -426,7 +426,7 @@ void oFonoConnection::addMMSToService(const QString &path, const QVariantMap &pr
     bool isRoom = false;
     MMSDMessage *msg = new MMSDMessage(path, properties);
     mServiceMMSList[servicePath].append(msg);
-    if (properties["Status"] ==  "received") {
+    if (properties["Status"] == "received") {
         QString senderNormalizedNumber = PhoneUtils::normalizePhoneNumber(properties["Sender"].toString());
         QStringList recipientList = properties["Recipients"].toStringList();
         // we use QSet to avoid having duplicate entries


### PR DESCRIPTION
Add/set headers to message when nuntium passes Received, Error, AllowRedownload and DeleteEvent parameters.
This is needed to propagate mms download error to history-service and/or delete previous error messages.

Note: This PR is accompanied by ubports/nuntium#8, [gitlab/ubports/core/history-service#8](https://gitlab.com/ubports/core/history-service/-/merge_requests/8), ubports/telephony-service#20 and ubports/messaging-app#260
Note: After building and deploying to phone with crossbuilder phone needs to be restarted for changes to apply.