### PR TITLE
fix sent date not properly displayed on pinephone

### DIFF
--- a/ofonotextchannel.cpp
+++ b/ofonotextchannel.cpp
@@ -461,6 +461,7 @@ void oFonoTextChannel::messageReceived(const QString &message, uint handle, cons
     Tp::MessagePart header;
     header["message-token"] = QDBusVariant(info["SentTime"].toString() +"-" + QString::number(mMessageCounter++));
     header["message-received"] = QDBusVariant(QDateTime::currentDateTime().toTime_t());
+    header["message-sent"] = QDBusVariant(QDateTime::fromString(info["SentTime"].toString(), Qt::ISODate).toTime_t());
     header["message-sender"] = QDBusVariant(handle);
     header["message-sender-id"] = QDBusVariant(mPhoneNumbers[0]);
     header["message-type"] = QDBusVariant(Tp::ChannelTextMessageTypeNormal);
@@ -479,6 +480,7 @@ void oFonoTextChannel::mmsReceived(const QString &id, uint handle, const QVarian
     header["message-token"] = QDBusVariant(id);
     header["message-sender"] = QDBusVariant(handle);
     header["message-received"] = QDBusVariant(QDateTime::currentDateTimeUtc().toTime_t());
+    header["message-sent"] = QDBusVariant(QDateTime::fromString(properties["SentTime"].toString(), Qt::ISODate).toTime_t());
     header["message-type"] = QDBusVariant(Tp::DeliveryStatusDelivered);
     header["x-canonical-mms"] = QDBusVariant(true);
     if (!subject.isEmpty())

--- a/ofonotextchannel.cpp
+++ b/ofonotextchannel.cpp
@@ -461,7 +461,7 @@ void oFonoTextChannel::messageReceived(const QString &message, uint handle, cons
     Tp::MessagePart header;
     header["message-token"] = QDBusVariant(info["SentTime"].toString() +"-" + QString::number(mMessageCounter++));
     header["message-received"] = QDBusVariant(QDateTime::currentDateTime().toTime_t());
-    header["message-sent"] = QDBusVariant(QDateTime::fromString(info["SentTime"].toString(), Qt::ISODate).toTime_t());
+    header["message-sent"] = QDBusVariant(getSentDate(info["SentTime"].toString()).toTime_t());
     header["message-sender"] = QDBusVariant(handle);
     header["message-sender-id"] = QDBusVariant(mPhoneNumbers[0]);
     header["message-type"] = QDBusVariant(Tp::ChannelTextMessageTypeNormal);
@@ -480,7 +480,7 @@ void oFonoTextChannel::mmsReceived(const QString &id, uint handle, const QVarian
     header["message-token"] = QDBusVariant(id);
     header["message-sender"] = QDBusVariant(handle);
     header["message-received"] = QDBusVariant(QDateTime::currentDateTimeUtc().toTime_t());
-    header["message-sent"] = QDBusVariant(QDateTime::fromString(properties["SentTime"].toString(), Qt::ISODate).toTime_t());
+    header["message-sent"] = QDBusVariant(getSentDate(properties["Date"].toString()).toTime_t());
     header["message-type"] = QDBusVariant(Tp::DeliveryStatusDelivered);
     header["x-canonical-mms"] = QDBusVariant(true);
     if (!subject.isEmpty())
@@ -517,4 +517,15 @@ void oFonoTextChannel::mmsReceived(const QString &id, uint handle, const QVarian
     }
 
     mTextChannel->addReceivedMessage(message);
+}
+
+QDateTime oFonoTextChannel::getSentDate(const QString &sentTime){
+    QDateTime dt = QDateTime::fromString(sentTime, Qt::ISODate);
+    QDateTime currentDate  = QDateTime::currentDateTimeUtc();
+    //some text message may not have the Sentime set, use the received one in that case
+    if (!dt.isValid() || dt > currentDate){
+        dt = currentDate;
+    }
+
+    return dt;
 }

--- a/ofonotextchannel.h
+++ b/ofonotextchannel.h
@@ -60,6 +60,7 @@ Q_SIGNALS:
 
 private:
     ~oFonoTextChannel();
+    QDateTime getSentDate(const QString &sentTime);
     Tp::BaseChannelPtr mBaseChannel;
     QStringList mPhoneNumbers;
     oFonoConnection *mConnection;


### PR DESCRIPTION
should fix: https://gitlab.com/ubports/community-ports/pinephone/-/issues/245

Cherry-picked the sent time management 