### PR TITLE
Auto swap calls on hangup if holding

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+telepathy-ofono (0.3+ubports2) xenial; urgency=medium
+
+  [ José Pekkarinen ]
+  * Auto swap calls when hanging up a call while holding.
+
+ -- José Pekkarinen <jose.pekkarinen@foxhound.fi>  Sat, 10 Jul 2021 14:03:13 +0000
+
 telepathy-ofono (0.3+ubports1) xenial; urgency=medium
 
   * sms/mms: use the received date when no sent date available

--- a/ofonocallchannel.cpp
+++ b/ofonocallchannel.cpp
@@ -120,7 +120,11 @@ void oFonoCallChannel::onHangup(uint reason, const QString &detailedReason, cons
 {
     // TODO: use the parameters sent by telepathy
     mRequestedHangup = true;
-    hangup();
+    if (mHoldIface->getHoldState() == Tp::LocalHoldStateHeld ||
+        mHoldIface->getHoldState() == Tp::LocalHoldStatePendingHold)
+        mConnection->voiceCallManager()->releaseAndSwap();
+    else
+        hangup();
 }
 
 void oFonoCallChannel::onAccept(Tp::DBusError*)


### PR DESCRIPTION
This patch adds a via to swap the calls
when we finish a call, and have calls holding,
to automatically swap to the call and release
the active one. Currently, when the active is
hanged up, the second keeps on hold, requiring
the user to press the pause button to resume
the holding one.

Signed-off-by: José Pekkarinen <jose.pekkarinen@foxhound.fi>