### PR TITLE
mc-plugin: Do not listen for ModemRemoved signal

### DIFF
--- a/mc-plugin/mcp-account-manager-ofono-on-ring.c
+++ b/mc-plugin/mcp-account-manager-ofono-on-ring.c
@@ -178,11 +178,6 @@ manager_proxy_signal_cb (GDBusProxy *proxy,
       g_variant_get (parameters, "(&o@a{sv})", &path, NULL);
       add_modem (self, path);
     }
-  else if (g_str_equal (signal_name, "ModemRemoved"))
-    {
-      g_variant_get (parameters, "(&o)", &path);
-      remove_modem (self, path);
-    }
 }
 
 static void


### PR DESCRIPTION
The ModemRemoved path appears to put Telepathy in a state where it is unable to reconnect to ofono. If we just don't listen to that signal, things magically continue to work after ofono restarts.

Possibly fixes https://github.com/ubports/ubuntu-touch/issues/1629. At least one case.