### PR TITLE
Changes needed for propagating error messages when MMS message is received

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -352,7 +352,7 @@ void oFonoConnection::addMMSToService(const QString &path, const QVariantMap &pr
     bool isRoom = false;
     MMSDMessage *msg = new MMSDMessage(path, properties);
     mServiceMMSList[servicePath].append(msg);
-    if (properties["Status"] ==  "received") {
+    if (properties["Status"] == "received") {
         QString senderNormalizedNumber = PhoneUtils::normalizePhoneNumber(properties["Sender"].toString());
         QStringList recipientList = properties["Recipients"].toStringList();
         // we use QSet to avoid having duplicate entries


### PR DESCRIPTION
- Fill MMS message headers according to properties on mmsReceived.
- Fix MMS message type on mmsReceived.
- Remove some spaces/newlines to have consistent formating.

Note: This is the same as https://github.com/ubports/telepathy-ofono/pull/20, but rebased onto the android9 branch.